### PR TITLE
Add codecov token to fix test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,5 @@ jobs:
         with:
           file: ./coverage.txt
           fail_ci_if_error: true
+          token: "${{ secrets.CODECOV_TOKEN }}"
         if: env.GIT_DIFF


### PR DESCRIPTION
It solves the tests pipeline failure by adding codecov token in github repository secrets